### PR TITLE
fix: missing aria-label from icon-only button

### DIFF
--- a/packages/client/src/modules/Shortcuts/Shortcuts.tsx
+++ b/packages/client/src/modules/Shortcuts/Shortcuts.tsx
@@ -18,6 +18,7 @@ export const Shortcuts = () => {
 						<h2 className="heading text-center font-bold text-slate-200">
 							{item.title}
 							<Button
+								aria-label="Edit section"
 								raw
 								className={
 									"ml-3 text-slate-300 hover:text-slate-400 active:text-slate-500"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- Accessibility Improvement: Enhanced the `Shortcuts` component with an `aria-label` attribute for better screen reader support. This update improves the user experience for individuals using assistive technologies, making our application more inclusive and accessible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->