### PR TITLE
fix: adding missing dependencies to bundle size reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"test": "lerna run test"
 	},
 	"devDependencies": {
-		"@node-cli/bundlesize": "3.0.1",
+		"@node-cli/bundlesize": "4.0.0",
 		"@versini/dev-dependencies-client": "4.1.9",
 		"@versini/dev-dependencies-types": "1.1.2",
 		"@versini/eslint-plugin-client": "1.0.1"

--- a/packages/client/bundlesize.config.js
+++ b/packages/client/bundlesize.config.js
@@ -13,12 +13,16 @@ export default {
 			limit: "12 kb",
 		},
 		{
+			path: "dist/assets/index-<hash>.css",
+			limit: "8 kb",
+		},
+		{
 			path: "dist/jsonUtilities-<hash>.js",
 			limit: "10 kb",
 		},
 		{
-			path: "dist/assets/index-<hash>.css",
-			limit: "8 kb",
+			path: "dist/react-<semver>.js",
+			limit: "46 kb",
 		},
 	],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -670,9 +670,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@node-cli/bundlesize@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@node-cli/bundlesize@npm:3.0.1"
+"@node-cli/bundlesize@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@node-cli/bundlesize@npm:4.0.0"
   dependencies:
     "@node-cli/logger": "npm:>=1.2.0"
     "@node-cli/parser": "npm:>=2.2.1"
@@ -682,7 +682,7 @@ __metadata:
     semver: "npm:7.5.4"
   bin:
     bundlesize: dist/bundlesize.js
-  checksum: 0d987fa1017cce4168603278bf5b7414fe6f6a2a525e618c48cc375035cf6a16901c00237487fa0ce0b84081548de4d0e2706f7bfac9df8e2d839709eb95fa26
+  checksum: 9e1ccc9b95783da1fe58e51b9a7d518f729d573c87cac8b911557802db01c4cb00e454e83071ac928461672e415a54d3b220a542982baf220526284460c2ac44
   languageName: node
   linkType: hard
 
@@ -10385,7 +10385,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root@workspace:."
   dependencies:
-    "@node-cli/bundlesize": "npm:3.0.1"
+    "@node-cli/bundlesize": "npm:4.0.0"
     "@versini/dev-dependencies-client": "npm:4.1.9"
     "@versini/dev-dependencies-types": "npm:1.1.2"
     "@versini/eslint-plugin-client": "npm:1.0.1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `@node-cli/bundlesize` dependency to version 4.0.0 for improved performance and stability.
- **Refactor**
	- Adjusted file size limits in `bundlesize.config.js` to optimize load times and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->