### PR TITLE
fix: removing position key from DB

### DIFF
--- a/packages/client/src/common/types.d.ts
+++ b/packages/client/src/common/types.d.ts
@@ -15,7 +15,6 @@ export type ShortcutDataProps = {
 
 export type SectionProps = {
 	id: string;
-	position: number;
 	shortcuts: ShortcutDataProps[];
 	title: string;
 };

--- a/packages/client/src/common/utilities.ts
+++ b/packages/client/src/common/utilities.ts
@@ -5,7 +5,6 @@ export const GRAPHQL_QUERIES = {
 	GET_SHORTCUTS: `query GetShortcuts($userId: String!) {
 		getUserSections(user: $userId) {
 			title
-			position
 			id
 			shortcuts {
 				id
@@ -14,10 +13,9 @@ export const GRAPHQL_QUERIES = {
 			}
 		}
 	}`,
-	SET_SHORTCUTS: `mutation SetShortcuts($userId: String!, $sectionId: ID!, $sectionTitle: String, $sectionPosition: Int, $shortcuts: [ShortcutInput]!) {
-		updateUserShortcuts(user: $userId, sectionId: $sectionId, sectionTitle: $sectionTitle, sectionPosition: $sectionPosition, shortcuts: $shortcuts) {
+	SET_SHORTCUTS: `mutation SetShortcuts($userId: String!, $sectionId: ID!, $sectionTitle: String, $shortcuts: [ShortcutInput]!) {
+		updateUserShortcuts(user: $userId, sectionId: $sectionId, sectionTitle: $sectionTitle, shortcuts: $shortcuts) {
 			title
-			position
 			id
 			shortcuts {
 				id

--- a/packages/client/src/modules/App/App.tsx
+++ b/packages/client/src/modules/App/App.tsx
@@ -54,7 +54,6 @@ function App() {
 						userId: FAKE_USER_EMAIL,
 						sectionId: state.sections[0].id,
 						sectionTitle: state.sections[0].title,
-						sectionPosition: state.sections[0].position,
 						shortcuts: state.sections[0].shortcuts,
 					},
 				});

--- a/packages/client/src/modules/App/__tests__/reducer.test.ts
+++ b/packages/client/src/modules/App/__tests__/reducer.test.ts
@@ -25,7 +25,6 @@ describe("Non-DOM tests", () => {
 				status: ACTION_STATUS_SUCCESS,
 				sections: [
 					{
-						position: 1,
 						title: "testTitle",
 						id: "testId",
 						shortcuts: [

--- a/packages/client/src/modules/Shortcuts/Shortcuts.tsx
+++ b/packages/client/src/modules/Shortcuts/Shortcuts.tsx
@@ -8,7 +8,7 @@ import { AppContext } from "../App/AppContext";
 
 export const Shortcuts = () => {
 	const { state, dispatch } = useContext(AppContext);
-	const [editable, setEditable] = useState<number | null>();
+	const [editable, setEditable] = useState<string | null>();
 	const [userInputShortcuts, setUserInputShortcuts] = useState("");
 	const [userInputSectionTitle, setUserInputSectionTitle] = useState("");
 
@@ -16,7 +16,7 @@ export const Shortcuts = () => {
 		<>
 			{state.sections.map((item) => {
 				return (
-					<div key={item.position} className="mb-5">
+					<div key={item.id} className="mb-5">
 						<h2 className="heading text-center font-bold text-slate-200">
 							{item.title}
 							<ButtonIcon
@@ -27,9 +27,7 @@ export const Shortcuts = () => {
 								className="ml-1"
 								label="Edit section"
 								onClick={() => {
-									setEditable(
-										editable === item.position ? null : item.position,
-									);
+									setEditable(editable === item.id ? null : item.id);
 									setUserInputSectionTitle(JSON.stringify(item.title, null, 2));
 									setUserInputShortcuts(
 										JSON.stringify(item.shortcuts, null, 2),
@@ -40,13 +38,13 @@ export const Shortcuts = () => {
 							</ButtonIcon>
 						</h2>
 
-						{editable && editable === item.position ? (
+						{editable && editable === item.id ? (
 							<>
 								<TextInput
 									mode="dark"
 									focusMode="light"
 									label="Section title"
-									name={`section-title-${item.position}`}
+									name={`section-title-${item.id}`}
 									className="mb-2 mt-2"
 									type="text"
 									value={userInputSectionTitle}
@@ -70,9 +68,7 @@ export const Shortcuts = () => {
 									focusMode="light"
 									className="mr-2 mt-3"
 									onClick={() => {
-										setEditable(
-											editable === item.position ? null : item.position,
-										);
+										setEditable(editable === item.id ? null : item.id);
 									}}
 								>
 									Cancel
@@ -82,9 +78,7 @@ export const Shortcuts = () => {
 									noBorder
 									className="mt-3"
 									onClick={async () => {
-										setEditable(
-											editable === item.position ? null : item.position,
-										);
+										setEditable(editable === item.id ? null : item.id);
 										try {
 											const { jsonParse, addUniqueId } = await import(
 												"../../common/jsonUtilities"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed the `position` property from `SectionProps` type and `sectionPosition` parameter from `SET_SHORTCUTS` GraphQL mutation, impacting related functionality.
	- Updated the `App` component and associated tests to reflect the removal of `sectionPosition`.
	- Changed the `Shortcuts` component to use string type for `editable` state and updated key references from `position` to `id`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->