### PR TITLE
fix: removing obsolete "id" from shortcut object

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -31,7 +31,6 @@
 		"@versini/ui-system": "1.2.0",
 		"json5": "2.2.3",
 		"react": "18.2.0",
-		"react-dom": "18.2.0",
-		"uuid": "9.0.1"
+		"react-dom": "18.2.0"
 	}
 }

--- a/packages/client/src/common/jsonUtilities.ts
+++ b/packages/client/src/common/jsonUtilities.ts
@@ -1,7 +1,4 @@
 import JSON5 from "json5";
-import { v4 as uuidv4 } from "uuid";
-
-import type { ShortcutDataProps } from "./types";
 
 /**
  * Function to wrap a string in double quotes if it is not already wrapped,
@@ -41,13 +38,4 @@ export const jsonParse = (json: string, autofix = false): any => {
 	} catch (error) {
 		throw new Error(`Invalid JSON format: ${error}`);
 	}
-};
-
-export const addUniqueId = (data: ShortcutDataProps[]): ShortcutDataProps[] => {
-	return data.map((item) => {
-		return {
-			...item,
-			id: uuidv4(),
-		};
-	});
 };

--- a/packages/client/src/common/types.d.ts
+++ b/packages/client/src/common/types.d.ts
@@ -8,7 +8,6 @@ import {
 } from "./constants";
 
 export type ShortcutDataProps = {
-	id: string;
 	label: string;
 	url: string;
 };

--- a/packages/client/src/common/utilities.ts
+++ b/packages/client/src/common/utilities.ts
@@ -7,7 +7,6 @@ export const GRAPHQL_QUERIES = {
 			title
 			id
 			shortcuts {
-				id
 				label
 				url
 			}
@@ -18,7 +17,6 @@ export const GRAPHQL_QUERIES = {
 			title
 			id
 			shortcuts {
-				id
 				label
 				url
 			}
@@ -29,7 +27,6 @@ export const GRAPHQL_QUERIES = {
 			title
 			id
 			shortcuts {
-				id
 				label
 				url
 			}
@@ -40,7 +37,6 @@ export const GRAPHQL_QUERIES = {
 			title
 			id
 			shortcuts {
-				id
 				label
 				url
 			}
@@ -51,7 +47,6 @@ export const GRAPHQL_QUERIES = {
 			title
 			id
 			shortcuts {
-				id
 				label
 				url
 			}

--- a/packages/client/src/modules/App/App.tsx
+++ b/packages/client/src/modules/App/App.tsx
@@ -13,7 +13,6 @@ import {
 import { IconDelete, IconDown, IconEdit, IconUp } from "@versini/ui-icons";
 import { Flexgrid, FlexgridItem } from "@versini/ui-system";
 import { lazy, Suspense, useEffect, useReducer, useRef, useState } from "react";
-import { v4 as uuidv4 } from "uuid";
 
 import {
 	ACTION_GET_DATA,
@@ -143,7 +142,10 @@ function App() {
 					userId: FAKE_USER_EMAIL,
 					sectionTitle: "New Section",
 					shortcuts: [
-						{ label: "New Shortcut", url: "https://example.com", id: uuidv4() },
+						{
+							label: "New Shortcut",
+							url: "https://example.com",
+						},
 					],
 				},
 			});

--- a/packages/client/src/modules/Shortcuts/Shortcuts.tsx
+++ b/packages/client/src/modules/Shortcuts/Shortcuts.tsx
@@ -14,11 +14,11 @@ export const Shortcuts = () => {
 
 	return state && state?.sections?.length > 0 ? (
 		<>
-			{state.sections.map((item) => {
+			{state.sections.map((section) => {
 				return (
-					<div key={item.id} className="mb-5">
+					<div key={section.id} className="mb-5">
 						<h2 className="heading text-center font-bold text-slate-200">
-							{item.title}
+							{section.title}
 							<ButtonIcon
 								focusMode="light"
 								mode="light"
@@ -27,10 +27,12 @@ export const Shortcuts = () => {
 								className="ml-1"
 								label="Edit section"
 								onClick={() => {
-									setEditable(editable === item.id ? null : item.id);
-									setUserInputSectionTitle(JSON.stringify(item.title, null, 2));
+									setEditable(editable === section.id ? null : section.id);
+									setUserInputSectionTitle(
+										JSON.stringify(section.title, null, 2),
+									);
 									setUserInputShortcuts(
-										JSON.stringify(item.shortcuts, null, 2),
+										JSON.stringify(section.shortcuts, null, 2),
 									);
 								}}
 							>
@@ -38,13 +40,13 @@ export const Shortcuts = () => {
 							</ButtonIcon>
 						</h2>
 
-						{editable && editable === item.id ? (
+						{editable && editable === section.id ? (
 							<>
 								<TextInput
 									mode="dark"
 									focusMode="light"
 									label="Section title"
-									name={`section-title-${item.id}`}
+									name={`section-title-${section.id}`}
 									className="mb-2 mt-2"
 									type="text"
 									value={userInputSectionTitle}
@@ -57,8 +59,8 @@ export const Shortcuts = () => {
 									textAreaClassName="font-mono text-sm"
 									mode="dark"
 									focusMode="light"
-									label={`Shortcuts for ${item.title}`}
-									name={`shortcuts-${item.id}`}
+									label={`Shortcuts for ${section.title}`}
+									name={`shortcuts-${section.id}`}
 									value={userInputShortcuts}
 									onChange={(e) => setUserInputShortcuts(e.target.value)}
 								/>
@@ -68,7 +70,7 @@ export const Shortcuts = () => {
 									focusMode="light"
 									className="mr-2 mt-3"
 									onClick={() => {
-										setEditable(editable === item.id ? null : item.id);
+										setEditable(editable === section.id ? null : section.id);
 									}}
 								>
 									Cancel
@@ -78,22 +80,13 @@ export const Shortcuts = () => {
 									noBorder
 									className="mt-3"
 									onClick={async () => {
-										setEditable(editable === item.id ? null : item.id);
+										setEditable(editable === section.id ? null : section.id);
 										try {
-											const { jsonParse, addUniqueId } = await import(
+											const { jsonParse } = await import(
 												"../../common/jsonUtilities"
 											);
 											try {
-												item.shortcuts = addUniqueId(
-													jsonParse(userInputShortcuts),
-												);
-											} catch (error) {
-												// eslint-disable-next-line no-console
-												console.error(error);
-											}
-
-											try {
-												item.title = jsonParse(userInputSectionTitle, true);
+												section.title = jsonParse(userInputSectionTitle, true);
 											} catch (error) {
 												// eslint-disable-next-line no-console
 												console.error(error);
@@ -103,7 +96,7 @@ export const Shortcuts = () => {
 												type: ACTION_SET_DATA,
 												payload: {
 													status: "stale",
-													section: item,
+													section: section,
 												},
 											});
 										} catch (error) {
@@ -117,11 +110,11 @@ export const Shortcuts = () => {
 							</>
 						) : (
 							<div className="flex flex-wrap justify-center">
-								{item.shortcuts.map((shortcut) => {
+								{section.shortcuts.map((shortcut) => {
 									return (
 										<ButtonLink
 											focusMode="light"
-											key={shortcut.id}
+											key={`${shortcut.url}-${shortcut.label}`}
 											noBorder
 											link={shortcut.url}
 											target="_blank"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
-      uuid:
-        specifier: 9.0.1
-        version: 9.0.1
     devDependencies:
       '@versini/ui-styles':
         specifier: 1.6.0
@@ -8777,6 +8774,7 @@ packages:
   /uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
+    dev: true
 
   /v8-to-istanbul@9.2.0:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed unused `uuid` dependency to streamline package size.
- **Refactor**
	- Simplified data handling by removing redundant `id` fields from shortcut data.
	- Enhanced code consistency by standardizing reference terms across modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->