### PR TITLE
fix: replacing browser router with hash router

### DIFF
--- a/packages/client/src/modules/App/AppBootstrap.tsx
+++ b/packages/client/src/modules/App/AppBootstrap.tsx
@@ -1,6 +1,6 @@
 import { AuthProvider, useAuth } from "@versini/auth-provider";
 import { Suspense, lazy, useReducer } from "react";
-import { RouterProvider, createBrowserRouter } from "react-router-dom";
+import { RouterProvider, createHashRouter } from "react-router-dom";
 
 import {
 	ACTION_STATUS_SUCCESS,
@@ -13,7 +13,7 @@ import { Root } from "../Layout/Root";
 
 const LazyApp = lazy(() => import("./App"));
 const LazySassySaint = lazy(() => import("./LazySassySaint"));
-const router = createBrowserRouter([
+const router = createHashRouter([
 	{
 		path: "/",
 		element: <Root />,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the app to use `createHashRouter` instead of `createBrowserRouter`, potentially improving routing behavior within the React application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->