### PR TITLE
feat: adding support for access token fallback via httpOnly cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,5 @@
 		"@versini/dev-dependencies-client": "5.1.1",
 		"@versini/dev-dependencies-types": "1.3.1"
 	},
-	"packageManager": "pnpm@9.4.0+sha512.f549b8a52c9d2b8536762f99c0722205efc5af913e77835dbccc3b0b0b2ca9e7dc8022b78062c17291c48e88749c70ce88eb5a74f1fa8c4bf5e18bb46c8bd83a"
+	"packageManager": "pnpm@9.5.0+sha512.140036830124618d624a2187b50d04289d5a087f326c9edfc0ccd733d76c4f52c3a313d4fc148794a2a9d81553016004e6742e8cf850670268a7387fc220c903"
 }

--- a/packages/client/bundlesize.config.js
+++ b/packages/client/bundlesize.config.js
@@ -9,15 +9,19 @@ export default {
 		 */
 		{
 			path: "dist/static/js/index.<hash>.js",
-			limit: "5 kb",
+			limit: "6 kb",
 		},
 		{
 			path: "dist/static/js/lib-react.<hash>.js",
 			limit: "45 kb",
 		},
 		{
-			path: "dist/static/js/vendors-*auth-provider*.<hash>.js",
-			limit: "55 kb",
+			path: "dist/static/js/lib-router.<hash>.js",
+			limit: "20 kb",
+		},
+		{
+			path: "dist/static/js/vendors-*uuid*.<hash>.js",
+			limit: "43 kb",
 		},
 		/**
 		 * JavaScript static async assets.
@@ -27,12 +31,8 @@ export default {
 			limit: "5 kb",
 		},
 		{
-			path: "dist/static/js/async/vendors-*uuid*.<hash>.js",
-			limit: "32 kb",
-		},
-		{
-			path: "dist/static/js/async/node_modules_*ui-components*.<hash>.js",
-			limit: "3 kb",
+			path: "dist/static/js/async/vendors-*node_modules_*ui-components*.<hash>.js",
+			limit: "6 kb",
 		},
 		/**
 		 * CSS static assets.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,7 +27,7 @@
 		"@versini/ui-styles": "1.9.3"
 	},
 	"dependencies": {
-		"@versini/auth-provider": "5.0.6",
+		"@versini/auth-provider": "5.1.1",
 		"@versini/sassysaint": "1.0.1",
 		"@versini/ui-components": "5.20.0",
 		"@versini/ui-form": "1.3.5",

--- a/packages/client/src/common/constants.ts
+++ b/packages/client/src/common/constants.ts
@@ -10,4 +10,4 @@ export const ACTION_SET_EDIT_SECTIONS = "action-set-edit-sections";
 export const LOCAL_STORAGE_PREFIX = "my-shortcuts";
 export const LOCAL_STORAGE_BASIC_AUTH = "basic-auth";
 
-export const DEFAULT_SESSION_EXPIRATION = "90d";
+export const CLIENT_ID = "b44c68f0-e5b3-4a1d-a3e3-df8632b0223b";

--- a/packages/client/src/common/utilities.ts
+++ b/packages/client/src/common/utilities.ts
@@ -3,6 +3,8 @@ import { v4 as uuidv4 } from "uuid";
 export const isProd = process.env.NODE_ENV === "production";
 export const isDev = !isProd;
 
+export const DOMAIN = isDev ? "gizmette.local.com" : "mylogin.gizmette.com";
+
 const GRAPHQL_QUERIES = {
 	GET_SHORTCUTS: `query GetShortcuts {
 		getUserSections {
@@ -122,6 +124,7 @@ const graphQLCall = async ({
 }) => {
 	const response = await fetch(`${process.env.PUBLIC_API_SERVER_URL}/graphql`, {
 		method: "POST",
+		credentials: "include",
 		headers: {
 			...headers,
 			"Content-Type": "application/json",

--- a/packages/client/src/modules/App/AppBootstrap.tsx
+++ b/packages/client/src/modules/App/AppBootstrap.tsx
@@ -2,10 +2,8 @@ import { AuthProvider, useAuth } from "@versini/auth-provider";
 import { Suspense, lazy, useReducer } from "react";
 import { RouterProvider, createHashRouter } from "react-router-dom";
 
-import {
-	ACTION_STATUS_SUCCESS,
-	DEFAULT_SESSION_EXPIRATION,
-} from "../../common/constants";
+import { ACTION_STATUS_SUCCESS, CLIENT_ID } from "../../common/constants";
+import { DOMAIN } from "../../common/utilities";
 import { AppContext } from "../../modules/App/AppContext";
 import { reducer } from "../../modules/App/reducer";
 import { Login } from "../../modules/Login/Login";
@@ -55,10 +53,7 @@ export const AppBootstrap = () => {
 		editSections: false,
 	});
 	return (
-		<AuthProvider
-			clientId={"b44c68f0-e5b3-4a1d-a3e3-df8632b0223b"}
-			sessionExpiration={DEFAULT_SESSION_EXPIRATION}
-		>
+		<AuthProvider clientId={CLIENT_ID} domain={DOMAIN}>
 			<AppContext.Provider value={{ state, dispatch }}>
 				<Bootstrap />
 			</AppContext.Provider>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   packages/client:
     dependencies:
       '@versini/auth-provider':
-        specifier: 5.0.6
-        version: 5.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 5.1.1
+        version: 5.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/sassysaint':
         specifier: 1.0.1
         version: 1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1153,11 +1153,11 @@ packages:
   '@types/yargs@17.0.32':
     resolution: {integrity: sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==}
 
-  '@versini/auth-common@2.10.1':
-    resolution: {integrity: sha512-OlSRFZPlKhRgRPs1RspUgn+GzCkgT6ecgDOIhe71w4y5usYbRG40qHDFkxl/S3dG+6v/4Yr0v2Zj6Sskvh6kYA==}
+  '@versini/auth-common@2.11.0':
+    resolution: {integrity: sha512-sZPkvnVnBrtuMaiSrenphlzJ+YvACGa12+aL1pzBwkFWmNDKTNaNMbF5R+LRCXJyqB0DkHQbX2g/E/UbghxQgA==}
 
-  '@versini/auth-provider@5.0.6':
-    resolution: {integrity: sha512-i9vXWSFq7L0VAjxIp/61CmhvujpyHifOolkQrzgCe0m4OnLg3tRT3kG8Soa3UbTryHuOssSK/+CifM8ZovgtFw==}
+  '@versini/auth-provider@5.1.1':
+    resolution: {integrity: sha512-icbGlS/023xcZlzyJYbKem/5c9ZTwf6FD+ok5iLOqk6welNxltgkotvoQeXfQUeN0U7ojw0OSJ8lEwvZNpLAEA==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
@@ -2672,9 +2672,6 @@ packages:
 
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
-
-  jose@5.6.2:
-    resolution: {integrity: sha512-F1t1/WZJ4JdmCE/XoMYw1dPOW5g8JF0xGm6Ox2fwaCAPlCzt+4Bh0EWP59iQuZNHHauDkCdjx+kCZSh5z/PGow==}
 
   jose@5.6.3:
     resolution: {integrity: sha512-1Jh//hEEwMhNYPDDLwXHa2ePWgWiFNNUadVmguAAw2IJ6sj9mNxV5tGXJNqlMkJAybF6Lgw1mISDxTePP/187g==}
@@ -5779,14 +5776,14 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@versini/auth-common@2.10.1':
+  '@versini/auth-common@2.11.0':
     dependencies:
-      jose: 5.6.2
+      jose: 5.6.3
       uuid: 10.0.0
 
-  '@versini/auth-provider@5.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/auth-provider@5.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@versini/auth-common': 2.10.1
+      '@versini/auth-common': 2.11.0
       '@versini/ui-hooks': 4.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       jose: 5.6.3
       react: 18.3.1
@@ -7573,8 +7570,6 @@ snapshots:
   jiti@1.21.0: {}
 
   jju@1.4.0: {}
-
-  jose@5.6.2: {}
 
   jose@5.6.3: {}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated `@versini/auth-provider` to version `5.1.1`.
  - Introduced `CLIENT_ID` and `DOMAIN` constants for improved configuration.

- **Improvements**
  - Adjusted JavaScript and CSS asset size limits in `bundlesize.config.js` for better performance.

- **Refactor**
  - Replaced hardcoded `clientId` and `sessionExpiration` props in `<AuthProvider>` component with `CLIENT_ID` and `DOMAIN` constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->