### PR TITLE
chore: using aliases for bundle sizes

### DIFF
--- a/configuration/rsbuild-bundlesize.config.js
+++ b/configuration/rsbuild-bundlesize.config.js
@@ -1,23 +1,10 @@
 import { defineConfig } from "@rsbuild/core";
-import { pluginReact } from "@rsbuild/plugin-react";
+
+import defaultConfig from "../packages/client/rsbuild.config";
 
 export default defineConfig({
-	source: {
-		entry: {
-			index: "./src/main.tsx",
-		},
-		define: {
-			"import.meta.env.BUILDTIME": "N/A",
-			"import.meta.env.BUILDVERSION": "N/A",
-		},
-	},
-	output: {
-		polyfill: "off",
-		cleanDistPath: true,
-		distPath: {
-			root: "./dist",
-		},
-	},
+	...defaultConfig,
+
 	tools: {
 		rspack: {
 			optimization: {
@@ -26,11 +13,4 @@ export default defineConfig({
 			},
 		},
 	},
-	html: {
-		template: "./index.html",
-	},
-	server: {
-		port: 5173,
-	},
-	plugins: [pluginReact()],
 });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"test": "lerna run test"
 	},
 	"devDependencies": {
-		"@node-cli/bundlesize": "4.1.1",
+		"@node-cli/bundlesize": "4.2.0",
 		"@versini/dev-dependencies-client": "5.1.1",
 		"@versini/dev-dependencies-types": "1.3.1"
 	},

--- a/packages/client/bundlesize.config.js
+++ b/packages/client/bundlesize.config.js
@@ -10,18 +10,22 @@ export default {
 		{
 			path: "dist/static/js/index.<hash>.js",
 			limit: "6 kb",
+			alias: "index.js",
 		},
 		{
 			path: "dist/static/js/lib-react.<hash>.js",
 			limit: "45 kb",
+			alias: "React",
 		},
 		{
 			path: "dist/static/js/lib-router.<hash>.js",
 			limit: "20 kb",
+			alias: "React Router",
 		},
 		{
 			path: "dist/static/js/vendors-*uuid*.<hash>.js",
 			limit: "43 kb",
+			alias: "Static vendors",
 		},
 		/**
 		 * JavaScript static async assets.
@@ -29,10 +33,17 @@ export default {
 		{
 			path: "dist/static/js/async/*App_App*.<hash>.js",
 			limit: "5 kb",
+			alias: "App",
+		},
+		{
+			path: "dist/static/js/async/node_modules_*ui-components*.<hash>.js",
+			limit: "6 kb",
+			alias: "UI components loader",
 		},
 		{
 			path: "dist/static/js/async/vendors-*node_modules_*ui-components*.<hash>.js",
 			limit: "6 kb",
+			alias: "UI components",
 		},
 		/**
 		 * CSS static assets.
@@ -40,6 +51,7 @@ export default {
 		{
 			path: "dist/static/css/index.<hash>.css",
 			limit: "11 kb",
+			alias: "index.css",
 		},
 	],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@node-cli/bundlesize':
-        specifier: 4.1.1
-        version: 4.1.1
+        specifier: 4.2.0
+        version: 4.2.0
       '@versini/dev-dependencies-client':
         specifier: 5.1.1
         version: 5.1.1(@microsoft/api-extractor@7.43.0(@types/node@20.14.10))(@swc/core@1.5.24(@swc/helpers@0.5.3))(@swc/helpers@0.5.3)(@types/jest@29.5.12)(@types/node@20.14.10)(@types/react-dom@18.3.0)(@types/react@18.3.3)(encoding@0.1.13)(happy-dom@14.12.3)(jsdom@24.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5)
@@ -457,8 +457,8 @@ packages:
   '@module-federation/webpack-bundler-runtime@0.1.6':
     resolution: {integrity: sha512-K5WhKZ4RVNaMEtfHsd/9CNCgGKB0ipbm/tgweNNeC11mEuBTNxJ09Y630vg3WPkKv9vfMCuXg2p2Dk+Q/KWTSA==}
 
-  '@node-cli/bundlesize@4.1.1':
-    resolution: {integrity: sha512-8C3fkC7HcBKAf75mqmRfXdN740Wh+1RPkUxo/tOVtO1Ek731GmhIRbSmY6m6E+zTEY10URq3di18Lt595iSI3Q==}
+  '@node-cli/bundlesize@4.2.0':
+    resolution: {integrity: sha512-a9mK/7GsA+EpSj1AvWww2MxCSr8fy0mKtdBHRWUyXxGaC6JRc6aP1xbHeCFSF4cvFlD3lrr/FWPNi0gYmxYUiw==}
     hasBin: true
 
   '@node-cli/logger@1.2.5':
@@ -2862,10 +2862,6 @@ packages:
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
-  lru-cache@10.2.0:
-    resolution: {integrity: sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==}
-    engines: {node: 14 || >=16.14}
-
   lru-cache@10.3.1:
     resolution: {integrity: sha512-9/8QXrtbGeMB6LxwQd4x1tIMnsmUxMvIH/qWGsccz6bt9Uln3S+sgAaqfQNhbGA8ufzs2fHuP/yqapGgP9Hh2g==}
     engines: {node: '>=18'}
@@ -5003,7 +4999,7 @@ snapshots:
       '@module-federation/runtime': 0.1.6
       '@module-federation/sdk': 0.1.6
 
-  '@node-cli/bundlesize@4.1.1':
+  '@node-cli/bundlesize@4.2.0':
     dependencies:
       '@node-cli/logger': 1.2.5
       '@node-cli/parser': 2.3.4
@@ -5047,7 +5043,7 @@ snapshots:
       agent-base: 7.1.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.4
-      lru-cache: 10.2.0
+      lru-cache: 10.3.1
       socks-proxy-agent: 8.0.2
     transitivePeerDependencies:
       - supports-color
@@ -5104,7 +5100,7 @@ snapshots:
   '@npmcli/git@5.0.4':
     dependencies:
       '@npmcli/promise-spawn': 7.0.1
-      lru-cache: 10.2.0
+      lru-cache: 10.3.1
       npm-pick-manifest: 9.0.0
       proc-log: 3.0.0
       promise-inflight: 1.0.1
@@ -5127,7 +5123,7 @@ snapshots:
   '@npmcli/map-workspaces@3.0.6':
     dependencies:
       '@npmcli/name-from-folder': 2.0.0
-      glob: 10.4.2
+      glob: 10.4.3
       minimatch: 9.0.4
       read-package-json-fast: 3.0.2
 
@@ -5149,7 +5145,7 @@ snapshots:
   '@npmcli/package-json@5.2.0':
     dependencies:
       '@npmcli/git': 5.0.4
-      glob: 10.4.2
+      glob: 10.4.3
       hosted-git-info: 7.0.1
       json-parse-even-better-errors: 3.0.1
       normalize-package-data: 6.0.0
@@ -6310,8 +6306,8 @@ snapshots:
     dependencies:
       '@npmcli/fs': 3.1.0
       fs-minipass: 3.0.3
-      glob: 10.4.2
-      lru-cache: 10.2.0
+      glob: 10.4.3
+      lru-cache: 10.3.1
       minipass: 7.1.2
       minipass-collect: 2.0.1
       minipass-flush: 1.0.5
@@ -6325,7 +6321,7 @@ snapshots:
     dependencies:
       '@npmcli/fs': 3.1.1
       fs-minipass: 3.0.3
-      glob: 10.4.2
+      glob: 10.4.3
       lru-cache: 10.3.1
       minipass: 7.1.2
       minipass-collect: 2.0.1
@@ -7208,7 +7204,7 @@ snapshots:
 
   hosted-git-info@7.0.1:
     dependencies:
-      lru-cache: 10.2.0
+      lru-cache: 10.3.1
 
   hosted-git-info@7.0.2:
     dependencies:
@@ -7845,8 +7841,6 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
-  lru-cache@10.2.0: {}
-
   lru-cache@10.3.1: {}
 
   lru-cache@6.0.0:
@@ -8057,7 +8051,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       exponential-backoff: 3.1.1
-      glob: 10.4.2
+      glob: 10.4.3
       graceful-fs: 4.2.11
       make-fetch-happen: 13.0.0
       nopt: 7.2.0
@@ -8748,7 +8742,7 @@ snapshots:
 
   rimraf@5.0.7:
     dependencies:
-      glob: 10.4.2
+      glob: 10.4.3
 
   rollup@4.18.0:
     dependencies:
@@ -9062,7 +9056,7 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       commander: 4.1.1
-      glob: 10.4.2
+      glob: 10.4.3
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to use a shared `defaultConfig` for bundle size settings.

- **New Features**
  - Added new aliases for JavaScript and CSS assets in the bundle size configuration for better identification. 

- **Dependencies**
  - Updated `@node-cli/bundlesize` to version `4.2.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->