### PR TITLE
fix: passing the right domain

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -28,7 +28,7 @@
 	},
 	"dependencies": {
 		"@versini/auth-provider": "5.1.1",
-		"@versini/sassysaint": "1.0.2",
+		"@versini/sassysaint": "1.0.3",
 		"@versini/ui-components": "5.20.0",
 		"@versini/ui-form": "1.3.5",
 		"@versini/ui-icons": "1.10.0",

--- a/packages/client/src/modules/App/LazySassySaint.tsx
+++ b/packages/client/src/modules/App/LazySassySaint.tsx
@@ -1,7 +1,8 @@
 import { SassySaint } from "@versini/sassysaint";
+import { DOMAIN } from "../../common/utilities";
 
 const LazySassySaint = () => {
-	return <SassySaint />;
+	return <SassySaint domain={DOMAIN} />;
 };
 
 export default LazySassySaint;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: 5.1.1
         version: 5.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/sassysaint':
-        specifier: 1.0.2
-        version: 1.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.0.3
+        version: 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-components':
         specifier: 5.20.0
         version: 5.20.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1171,8 +1171,8 @@ packages:
   '@versini/dev-dependencies-types@1.3.1':
     resolution: {integrity: sha512-jaIEB8wXomAkRxv/aVbeaoZY/vz6jftIalTdFIN3iyXY9v4yXV+hU5zSwCZAbP4xe/il5DnKYFHjyeEVXqhB3g==}
 
-  '@versini/sassysaint@1.0.2':
-    resolution: {integrity: sha512-di97FYY9g0L/FUDAYj8OEenV3q1M4tgA+nUeviZkCnIDw76C34B2r2m3oe1I4N7HNUoDceJsvhshU6pNd3AJdA==}
+  '@versini/sassysaint@1.0.3':
+    resolution: {integrity: sha512-03g5MO2gU+/YEtzu+x2EX0ZlezC/26ROIzGRF41UrXm5WpbOlWobG0UhJjOR95YTRk7DEytitoe0O3wGduYiaQ==}
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
@@ -5882,7 +5882,7 @@ snapshots:
       '@types/uuid': 10.0.0
       '@types/yargs': 17.0.32
 
-  '@versini/sassysaint@1.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/sassysaint@1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@versini/ui-hooks': 4.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
@@ -9337,7 +9337,7 @@ snapshots:
     dependencies:
       browserslist: 4.23.0
       escalade: 3.1.2
-      picocolors: 1.0.0
+      picocolors: 1.0.1
 
   uri-js@4.4.1:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the `LazySassySaint` component to utilize a `domain` prop for improved functionality.

- **Chores**
  - Updated `@versini/sassysaint` dependency to version 1.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->