### PR TITLE
feat: bump to the most recent auth provider

### DIFF
--- a/packages/client/bundlesize.config.js
+++ b/packages/client/bundlesize.config.js
@@ -24,7 +24,7 @@ export default {
 		},
 		{
 			path: "dist/static/js/vendors-*uuid*.<hash>.js",
-			limit: "45 kb",
+			limit: "46 kb",
 			alias: "Static vendors",
 		},
 		/**

--- a/packages/client/bundlesize.config.js
+++ b/packages/client/bundlesize.config.js
@@ -24,7 +24,7 @@ export default {
 		},
 		{
 			path: "dist/static/js/vendors-*uuid*.<hash>.js",
-			limit: "43 kb",
+			limit: "45 kb",
 			alias: "Static vendors",
 		},
 		/**

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,11 +27,11 @@
 		"@versini/ui-styles": "1.9.3"
 	},
 	"dependencies": {
-		"@versini/auth-provider": "5.1.3",
-		"@versini/sassysaint": "1.0.4",
+		"@versini/auth-provider": "6.0.0",
+		"@versini/sassysaint": "1.0.5",
 		"@versini/ui-components": "5.20.0",
 		"@versini/ui-form": "1.3.6",
-		"@versini/ui-icons": "1.10.0",
+		"@versini/ui-icons": "1.11.0",
 		"@versini/ui-system": "1.4.2",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -28,7 +28,7 @@
 	},
 	"dependencies": {
 		"@versini/auth-provider": "6.0.0",
-		"@versini/sassysaint": "1.0.5",
+		"@versini/sassysaint": "1.0.6",
 		"@versini/ui-components": "5.20.0",
 		"@versini/ui-form": "1.3.6",
 		"@versini/ui-icons": "1.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: 6.0.0
         version: 6.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/sassysaint':
-        specifier: 1.0.5
-        version: 1.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.0.6
+        version: 1.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-components':
         specifier: 5.20.0
         version: 5.20.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1165,8 +1165,8 @@ packages:
   '@versini/dev-dependencies-types@1.3.1':
     resolution: {integrity: sha512-jaIEB8wXomAkRxv/aVbeaoZY/vz6jftIalTdFIN3iyXY9v4yXV+hU5zSwCZAbP4xe/il5DnKYFHjyeEVXqhB3g==}
 
-  '@versini/sassysaint@1.0.5':
-    resolution: {integrity: sha512-wNvwWfqT1JDbkcAdBXCnt1qPZm8Dhj8zEAu+9Z909ESRQeKiuNb6R6gFs674lgrl+j2oKDC6pDnW5rCvsnWk3w==}
+  '@versini/sassysaint@1.0.6':
+    resolution: {integrity: sha512-EFwAbPdQJUGrcXNUDJlCG+koAw3a0MN0ijnQ05u7XiAovB/ia1Z8i7mzBFbzgQyu+AI2lN+BWnxAzBlzXmrZgA==}
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
@@ -5857,7 +5857,7 @@ snapshots:
       '@types/uuid': 10.0.0
       '@types/yargs': 17.0.32
 
-  '@versini/sassysaint@1.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/sassysaint@1.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@versini/ui-hooks': 4.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,11 +21,11 @@ importers:
   packages/client:
     dependencies:
       '@versini/auth-provider':
-        specifier: 5.1.3
-        version: 5.1.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 6.0.0
+        version: 6.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/sassysaint':
-        specifier: 1.0.4
-        version: 1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.0.5
+        version: 1.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-components':
         specifier: 5.20.0
         version: 5.20.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -33,8 +33,8 @@ importers:
         specifier: 1.3.6
         version: 1.3.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-icons':
-        specifier: 1.10.0
-        version: 1.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.11.0
+        version: 1.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-system':
         specifier: 1.4.2
         version: 1.4.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -893,6 +893,12 @@ packages:
     resolution: {integrity: sha512-sRU6nblDBQ4pVTWni019Kij+XQj4RP75WXN5z3qHk81dt/L8A7r3v8RgRInTup4/Jf90WNods9CcbnWj7zJ26w==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  '@simplewebauthn/browser@10.0.0':
+    resolution: {integrity: sha512-hG0JMZD+LiLUbpQcAjS4d+t4gbprE/dLYop/CkE01ugU/9sKXflxV5s0DRjdz3uNMFecatRfb4ZLG3XvF8m5zg==}
+
+  '@simplewebauthn/types@10.0.0':
+    resolution: {integrity: sha512-SFXke7xkgPRowY2E+8djKbdEznTVnD5R6GO7GPTthpHrokLvNKw8C3lFZypTxLI7KkCfGPfhtqB3d7OVGGa9jQ==}
+
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
@@ -1141,11 +1147,11 @@ packages:
   '@types/yargs@17.0.32':
     resolution: {integrity: sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==}
 
-  '@versini/auth-common@2.11.0':
-    resolution: {integrity: sha512-sZPkvnVnBrtuMaiSrenphlzJ+YvACGa12+aL1pzBwkFWmNDKTNaNMbF5R+LRCXJyqB0DkHQbX2g/E/UbghxQgA==}
+  '@versini/auth-common@2.12.1':
+    resolution: {integrity: sha512-JSeWi4Z1am4KUMbhXLtUKqZ6jPw23P4SdVwR7dw4CtGZbtFfj5QP3DdUhOJX0I6YU63pXKCPmU/zdKZUkzQKcQ==}
 
-  '@versini/auth-provider@5.1.3':
-    resolution: {integrity: sha512-n2QTQs8Mws/k5mqekwn3jjtymuzqSl7+5HXgbKSAhtCukMCfbjCCDOPzvAuX0croHszDi/0bqOTeARzIymLKYg==}
+  '@versini/auth-provider@6.0.0':
+    resolution: {integrity: sha512-kVgOcu3ybTTCk3jics15AiZHYlB0Dt/pL7TjDd5bQ81pjvNSVomj6sy4kizSXUcktJ7dGVOlVrvxIxCR3nbpkw==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
@@ -1159,8 +1165,8 @@ packages:
   '@versini/dev-dependencies-types@1.3.1':
     resolution: {integrity: sha512-jaIEB8wXomAkRxv/aVbeaoZY/vz6jftIalTdFIN3iyXY9v4yXV+hU5zSwCZAbP4xe/il5DnKYFHjyeEVXqhB3g==}
 
-  '@versini/sassysaint@1.0.4':
-    resolution: {integrity: sha512-PrJAWloPHJisUgJmdxCZTaRI85JvPJe0Bj2kFurMheuH2dbo609tnua5mzqpDLaBHlBpDqJjV1SYfAbjpe8uTw==}
+  '@versini/sassysaint@1.0.5':
+    resolution: {integrity: sha512-wNvwWfqT1JDbkcAdBXCnt1qPZm8Dhj8zEAu+9Z909ESRQeKiuNb6R6gFs674lgrl+j2oKDC6pDnW5rCvsnWk3w==}
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
@@ -1185,6 +1191,12 @@ packages:
 
   '@versini/ui-icons@1.10.0':
     resolution: {integrity: sha512-qJ+MacJle2UH1HdAblum/ThDXGAbfKKefWTemnI+WbegBV6C2V5ABOUI1iQGkA2piO5QaBF51UOwG3TyKHXwjQ==}
+    peerDependencies:
+      react: ^18.3.1
+      react-dom: ^18.3.1
+
+  '@versini/ui-icons@1.11.0':
+    resolution: {integrity: sha512-ALorSe1Q6wmxTl0PvyrMO3hCfaffZzPfcb4d+P5G+NizACWBWeAHp+GefqdvKLPJb/AwMBprw6LlGaTHauZB0A==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
@@ -5479,6 +5491,12 @@ snapshots:
       '@sigstore/core': 1.0.0
       '@sigstore/protobuf-specs': 0.2.1
 
+  '@simplewebauthn/browser@10.0.0':
+    dependencies:
+      '@simplewebauthn/types': 10.0.0
+
+  '@simplewebauthn/types@10.0.0': {}
+
   '@sinclair/typebox@0.27.8': {}
 
   '@swc/core-darwin-arm64@1.5.24':
@@ -5711,14 +5729,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@versini/auth-common@2.11.0':
+  '@versini/auth-common@2.12.1':
     dependencies:
       jose: 5.6.3
       uuid: 10.0.0
 
-  '@versini/auth-provider@5.1.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/auth-provider@6.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@versini/auth-common': 2.11.0
+      '@simplewebauthn/browser': 10.0.0
+      '@versini/auth-common': 2.12.1
       '@versini/ui-hooks': 4.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       jose: 5.6.3
       react: 18.3.1
@@ -5838,7 +5857,7 @@ snapshots:
       '@types/uuid': 10.0.0
       '@types/yargs': 17.0.32
 
-  '@versini/sassysaint@1.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/sassysaint@1.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@versini/ui-hooks': 4.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
@@ -5876,6 +5895,12 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   '@versini/ui-icons@1.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@versini/ui-private': 1.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@versini/ui-icons@1.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@versini/ui-private': 1.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1


### PR DESCRIPTION
### **PR Type**
Enhancement, Dependencies


___

### **Description**
- Updated `@versini/auth-provider` dependency from version 5.1.3 to 6.0.0 in `package.json` and `pnpm-lock.yaml`.
- Updated `@versini/sassysaint` dependency from version 1.0.4 to 1.0.5 in `package.json` and `pnpm-lock.yaml`.
- Updated `@versini/ui-icons` dependency from version 1.10.0 to 1.11.0 in `package.json` and `pnpm-lock.yaml`.
- Added new dependencies `@simplewebauthn/browser` and `@simplewebauthn/types` at version 10.0.0 in `pnpm-lock.yaml`.
- Updated `@versini/auth-common` dependency from version 2.11.0 to 2.12.1 in `pnpm-lock.yaml`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump versions for auth provider, sassysaint, and ui-icons</code></dd></summary>
<hr>

packages/client/package.json

<li>Updated <code>@versini/auth-provider</code> from 5.1.3 to 6.0.0<br> <li> Updated <code>@versini/sassysaint</code> from 1.0.4 to 1.0.5<br> <li> Updated <code>@versini/ui-icons</code> from 1.10.0 to 1.11.0<br>


</details>


  </td>
  <td><a href="https://github.com/aversini/mylogin-ui/pull/278/files#diff-26d3d28d31824ef26252df77cca08d24faea8451cb8fd3ffee2000f9e496daa0">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pnpm-lock.yaml</strong><dd><code>Update pnpm lock file for new dependency versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pnpm-lock.yaml

<li>Updated lock file entries for <code>@versini/auth-provider</code> to 6.0.0<br> <li> Updated lock file entries for <code>@versini/sassysaint</code> to 1.0.5<br> <li> Updated lock file entries for <code>@versini/ui-icons</code> to 1.11.0<br> <li> Added new dependencies for <code>@simplewebauthn/browser</code> and <br><code>@simplewebauthn/types</code> at 10.0.0<br> <li> Updated <code>@versini/auth-common</code> to 2.12.1<br>


</details>


  </td>
  <td><a href="https://github.com/aversini/mylogin-ui/pull/278/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb">+41/-16</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

