### PR TITLE
fix: only check for grants on load / refresh

### DIFF
--- a/packages/client/src/modules/Settings/Settings.tsx
+++ b/packages/client/src/modules/Settings/Settings.tsx
@@ -22,6 +22,7 @@ export const Settings = () => {
 
 	const isEditGrantedRef = useRef(false);
 	const isSassyGrantedRef = useRef(false);
+	const effectToGetGrantsDidRun = useRef(false);
 
 	const onClickConfirmLogout = () => {
 		setShowConfirmation(!showConfirmation);
@@ -43,6 +44,9 @@ export const Settings = () => {
 	 * is doing the same checks, but cannot be modified by the client.
 	 */
 	useEffect(() => {
+		if (effectToGetGrantsDidRun.current) {
+			return;
+		}
 		(async () => {
 			try {
 				const token = await getAccessToken();
@@ -54,6 +58,9 @@ export const Settings = () => {
 				console.error("Failed to fetch token or check grants:", error);
 			}
 		})();
+		return () => {
+			effectToGetGrantsDidRun.current = true;
+		};
 	}, [getAccessToken]);
 
 	return (


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added a `useRef` hook named `effectToGetGrantsDidRun` to track if the effect to get grants has already run.
- Updated the `useEffect` to check this ref and return early if the effect has already executed, preventing redundant grant checks.
- Set the `effectToGetGrantsDidRun` ref to `true` after the effect runs to ensure it doesn't run again.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Settings.tsx</strong><dd><code>Prevent redundant grant checks on component load</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/client/src/modules/Settings/Settings.tsx

<li>Added a <code>useRef</code> hook to track if the effect to get grants has run.<br> <li> Modified the <code>useEffect</code> to check and set this ref to prevent redundant <br>executions.<br>


</details>


  </td>
  <td><a href="https://github.com/aversini/mylogin-ui/pull/291/files#diff-e546a2ebd0b0dc9aa7affb4df71cafbfc6c79eeb649461607d40f57ae2e7efd2">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

